### PR TITLE
Fix low AR buff

### DIFF
--- a/ojsama.js
+++ b/ojsama.js
@@ -1642,7 +1642,7 @@ std_ppv2.prototype.calc = function(params) {
   if (mapstats.ar > 10.33) {
     ar_bonus += 0.4 * (mapstats.ar - 10.33);
   } else if (mapstats.ar < 8.0) {
-    ar_bonus += 0.1 * (8.0 - mapstats.ar);
+    ar_bonus += 0.01 * (8.0 - mapstats.ar);
   }
 
   ar_bonus = 1.0 + Math.min(ar_bonus, ar_bonus * (nobjects / 1000.0));


### PR DESCRIPTION
I just realized they had reverted the low ar buff before finalizing the recent changes so the calculation was off for <ar8 scores. Kinda sad but this fixes it.